### PR TITLE
Improve first tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Renovate - Hands On Tutorial
 
-
 ## Introduction
 
 Welcome to the Renovate hands-on tutorial.
@@ -15,10 +14,10 @@ In this tutorial, you will learn how to configure Renovate and become familiar w
 
 What you will learn:
 
-- 1 Installation
-- 1 Onboarding
-- 1 Getting to know Renovate’s update PRs
-- 1 Dependency Dashboard 
+1. Installation
+2. Onboarding
+3. Getting to know Renovate’s update PRs
+4. Dependency Dashboard 
 
 We will begin this tutorial with configuring and installing the Renovate app and an overview of the default settings and basic functionalities. 
 
@@ -28,15 +27,15 @@ Later, we will dive deeper into functional use-cases, advanced features, and `be
 
 Let’s start by forking the tutorial repo to your account, installing the Renovate GitHub App, and configuring it to your repo.
  
-- 1 Make sure you are logged in to GitHub.com
-- 1 Fork this [RenovateTutorial](https://github.com/PhilipAbed/RenovateTutorial) repository. The tutorial instructions will be based on the contents of this repository
-- 1 The following instructions are directed at those that don’t have Renovate installed:
+1. Make sure you are logged in to GitHub.com
+1. Fork this [RenovateTutorial](https://github.com/PhilipAbed/RenovateTutorial) repository. The tutorial instructions will be based on the contents of this repository
+1. The following instructions are directed at those that don’t have Renovate installed:
    - Install the Renovate App to your account by navigating to the [Renovate App GitHub installation page](https://github.com/apps/renovate) and select Install:
    ![image](https://user-images.githubusercontent.com/102745725/178965463-525a385e-d914-4309-aeb4-cb4358dc12bc.png)
--1 If you do have Renovate installed:
+1. If you do have Renovate installed:
    - navigate to the [Renovate app page](https://github.com/apps/renovate) and select configure:
    ![image](https://user-images.githubusercontent.com/42116482/178491021-a0b7ba34-3bc7-4953-8452-416fbd3d6ec9.png)
-- 1 You will reach an installation configuration page where you are asked to configure Repository Access. 
+1. You will reach an installation configuration page where you are asked to configure Repository Access. 
 
 > **Note**
 > for existing users, installation configuration appears at the bottom of the page.
@@ -47,12 +46,12 @@ Let’s start by forking the tutorial repo to your account, installing the Renov
        > each selected repo gets an onboarding PR. 
 
        If you select `All repositories`, forked repos will be skipped by default (including RenovateTutorial). 
-   - click on `Install` (“Save” for existing users)
+   - Click on `Install` (“Save” for existing users)
 
 <img width="629" alt="configuration page" src="https://user-images.githubusercontent.com/102745725/178964980-df55dafd-f087-433a-90f7-986fa01c1ac0.png">
 
+For new installs:
 
-For new installs:	
 - You will be redirected to our “Thank you for installing Renovate” page while we are setting up your account. 
 
 ![image](https://user-images.githubusercontent.com/42116482/178492276-ac0f5c03-db21-482c-95e9-07dc229ac298.png)
@@ -65,7 +64,7 @@ For new installs:
 
 ## Part 2 - Onboarding
 
-Now that you have Renovate installed, we can begin onboarding.
+Now you have installed Renovate, we can begin onboarding.
 
 Let’s review the concepts of the Onboarding PR and learn about Renovate’s initial settings.
 
@@ -76,8 +75,9 @@ Let’s review the concepts of the Onboarding PR and learn about Renovate’s in
 - This PR is there to help you understand Renovate and its default settings before Renovate starts running on your repository.
 - The Onboarding PR creates a configuration file called `renovate.json`, which contains Renovate’s default settings and can be modified during onboarding.
 
-Now let’s review the onboarding PR - 
-- 1 Navigate to the `Pull Requests` section in GitHub, and open the newly generated PR - `Configure Renovate`
+Let’s review the onboarding PR:
+
+1. Navigate to the `Pull Requests` section in GitHub, and open the newly generated PR - `Configure Renovate`
 
 <img width="1500" alt="onboarding PR" src="https://user-images.githubusercontent.com/102745725/178965966-76aa3941-cac4-4df3-bd89-75b9f8002924.png">
 
@@ -112,15 +112,15 @@ Example
 As a user, despite Renovate’s suggestion to limit hourly PR creation to 2, we might want to increase the limit to a different number.
 Let’s try changing this hourly limitation to 3:
 
-- 1 Go to the newly created branch - `renovate/configure`:
+1. Go to the newly created branch - `renovate/configure`:
 
 <img width="763" alt="new branch" src="https://user-images.githubusercontent.com/102745725/178966974-35c089c6-4190-4721-b1c2-956d84e80d07.png">
 
-- 1 Go into the `renovate.json` file:
+2. Go into the `renovate.json` file:
 
 ![image](https://user-images.githubusercontent.com/42116482/178494908-89189f2e-632a-42ee-a49a-16941a40101b.png)
 
-- 1 Add the following code segment:
+3. Add the following code segment:
 ```json
 {
   "prHourlyLimit": 3
@@ -128,15 +128,15 @@ Let’s try changing this hourly limitation to 3:
 ```
 <img width="591" alt="change in config 1" src="https://user-images.githubusercontent.com/102745725/178967120-51ec5940-42bc-444e-8c4d-b98ea4ee5948.png">
 
-- 1 Commit the changes
-- 1 Revisit the onboarding PR and notice how the onboarding PR automatically updates to reflect the changes you made to the configuration 
+4. Commit the changes
+5. Revisit the onboarding PR and notice how the onboarding PR automatically updates to reflect the changes you made to the configuration 
 
 <img width="830" alt="onboarding warning hourly update" src="https://user-images.githubusercontent.com/102745725/178960884-40077a5c-8fe1-422f-81c1-567ea1e6619b.png">
 
 > **Note**
 > May take a few moments to update.
 
-- 1 Merge the onboarding pull request.
+6. Merge the onboarding pull request.
 
 **Congratulations! You have successfully onboarded Renovate.** 🎈
 
@@ -153,11 +153,12 @@ Here we will review the basic concepts of Renovate update PRs and merge it.
 - You should already see notifications for these pull requests in the `Pull Requests` section of the repo.
 
 Let’s go ahead and take a look at a Renovate update PR:
-- 1 Navigate to the `Pull requests` section and open - `Update dependency lodash to x.y.z`
+1. Navigate to the `Pull requests` section and open - `Update dependency lodash to x.y.z`
 
 <img width="1256" alt="open PRs" src="https://user-images.githubusercontent.com/102745725/178967929-690b3866-190b-4576-a961-981ce78cbd1b.png">
 
 ### Each update PR contains:
+
 - Dependency information (name and version changes)
 - [Merge Confidence](https://docs.renovatebot.com/merge-confidence/) values
 - Up-to-date release notes
@@ -171,7 +172,7 @@ Let’s go ahead and take a look at a Renovate update PR:
 
 <img width="1488" alt="file diff lodash" src="https://user-images.githubusercontent.com/102745725/178968020-865560f7-173c-4e9e-a073-488147dbb137.png">
 
-- 1 Merge this pull request
+1. Merge this pull request
 
 >Note - Renovate is highly configurable and supports:
 >
@@ -193,9 +194,9 @@ In this section, we will go over some of its main functionalities and capabiliti
 Let’s begin by creating and enabling the Dependency Dashboard.
 Since GitHub defaults to disable `issues` on forked repositories, we need to enable it on the forked RenovateTutorial repo:
 
-- 1 Go to the main page of the repo
-- 1 Go to `settings` -> `general`
-- 1 Check the `issues` checkbox under the Features section:
+1. Go to the main page of the repo
+1. Go to `settings` -> `general`
+1. Check the `issues` checkbox under the Features section:
 
 <img width="1284" alt="issues settings" src="https://user-images.githubusercontent.com/102745725/178968523-fb002cf1-2510-4b4f-b840-f9776e660d92.png">
 
@@ -204,17 +205,15 @@ Since GitHub defaults to disable `issues` on forked repositories, we need to ena
 > **Note**
 > This is usually done in a click via the Dependency Dashboard.
 
-
-- 1 Go to the `Pull requests` section
-- 1 Select `Update dependency php to v8.1` and select `Close pull request`
+1. Go to the `Pull requests` section
+2. Select `Update dependency php to v8.1` and select `Close pull request`
 
 <img width="927" alt="close php" src="https://user-images.githubusercontent.com/102745725/178969009-7239db99-4abe-44d1-a86c-a0effdf6fb7a.png">
 
-- 1 This will trigger Renovate to run and the Dependency Dashboard will appear under the `Issues` section - navigate to it
+3. This will trigger Renovate to run and the Dependency Dashboard will appear under the `Issues` section - navigate to it
 
 > **Note**
-> it may take a minute to appear.
-
+> It may take a minute to appear.
 
 ### The Dependency Dashboard includes:
   - Overview of all updates that are still to-do:
@@ -236,24 +235,23 @@ You can also re-run the Renovate bot manually directly from the Dependency Dashb
 
  <img width="867" alt="rerun renovate" src="https://user-images.githubusercontent.com/102745725/178969114-c1b64333-b45a-4508-b638-1e25ad0adab5.png">
  
-
-Let’s dive into one of the dependency dashboard capabilities - **the Pending Approval feature**. 
+Let’s dive into one of the Dependency Dashboard capabilities - **the Pending Approval feature**. 
 
 Say we want to take extra measures before updating major versions of a package (either to reduce noise or to handle it more carefully).
 Renovate offers an option to prevent automatic creation of major version update PRs and create such PRs only upon manual request from the Dependency Dashboard. 
 
-In the Dependency Dasboard, under the `Rate Limited` section, the `Update dependency commander to vX` is waiting to be created.
+In the Dependency Dashboard, under the `Rate Limited` section, the `Update dependency commander to vX` is waiting to be created.
 
 > **Note**
-> based on the previously set `prHourlyLimit` configuration, 3 PRs per hour in our case, this PR will be created within an hour.
+> Based on the previously set `prHourlyLimit` configuration, 3 PRs per hour in our case, this PR will be created within an hour.
 
 <img width="928" alt="commander in Rate Limited" src="https://user-images.githubusercontent.com/102745725/178960104-c254c12f-08fb-4508-824d-20df60b2290f.png">
 
-Since we decided that we want to handle it manually, we will edit configurations and see how the dependency dashboard is affected by this change. 
+Since we decided that we want to handle it manually, we will edit configurations and see how the Dependency Dashboard is affected by this change. 
 
-In order to limit all major updates to on-demand creation:
+In order to limit all `major` updates to on-demand creation:
 
-- 1 Add this code segment to your `renovate.json` file:
+1. Add this code segment to your `renovate.json` file:
 ```json
 "packageRules": [
     {
@@ -265,44 +263,44 @@ In order to limit all major updates to on-demand creation:
 
 <img width="924" alt="change in config - pending approval" src="https://user-images.githubusercontent.com/102745725/178962677-612e8172-fac7-45fb-937b-46a559d848f0.png">
 
-- 1 Commit the changes
+2. Commit the changes
 
 > **Note**
-> Changing the `renovate.json` configuraion file is a webhook that triggers Renovate to re-run.
+> Changing the `renovate.json` configuration file is a webhook that triggers Renovate to re-run.
 
-- 1 Now go back to the Dependency Dashboard in the Issues section
-
-- 1 As you can see, `commander` major update PR now appears under the **Pending Approval** section and **will not** be opened unless manually triggered
+3. Now go back to the Dependency Dashboard in the Issues section
+4. As you can see, `commander` major update PR now appears under the **Pending Approval** section and **will not** be opened unless manually triggered
 
      > **Note**
      > it make take a minute to complete Renovate's run 
 
 <img width="926" alt="commander in pending approval" src="https://user-images.githubusercontent.com/102745725/178962735-84f1ae00-df4c-4fed-adf5-12fefeb94e9f.png">
 
-- 1 You can now decide to manually open this PR by checking the box next to it
-
-- 1 Navigate to the `Pull requests` section to review the generated PR and merge it to the repo.
-
+5. You can now decide to manually open this PR by checking the box next to it
+6. Navigate to the `Pull requests` section to review the generated PR and merge it to the repo.
 
 **Congratulations! You are now familiar with Renovate’s Dependency Dashboard.** 🎈
 
-## What have we learned so far:
-  - How to install Renovate
-  - Onboarding Renovate by reviewing, configuring, and merging the onboarding PR
-  - How to update a dependency with Renovate
-  - How to utilize the Dependency Dashboard
+## What you learned:
+
+- How to install Renovate
+- Onboarding Renovate by reviewing, configuring, and merging the onboarding PR
+- How to update a dependency with Renovate
+- How to utilize the Dependency Dashboard
   
 ### General Comments:
-  - Granting access to all repositories or change repo selections can be modified at any time on the [Renovate App GitHub page](https://github.com/apps/renovate).
-  - Renovate configuration can be modified by manual configurations, global organization configurations and existing Renovate presets.
 
-### Congratulations! You have successfully completed Renovate’s hands-on tutorial and have taken your first steps to automate dependency updates in your projects.
+- Granting access to all repositories or change repo selections can be modified at any time on the [Renovate App GitHub page](https://github.com/apps/renovate).
+- Renovate configuration can be modified by manual configurations, global organization configurations and existing Renovate presets.
 
-### Now, it's time to configure Renovate on the rest of your repositories and let Renovate manage your dependencies' health.
+### Congratulations!
+
+You have successfully completed Renovate’s hands-on tutorial and have taken your first steps to automate dependency updates in your projects.
+Now, it's time to configure Renovate on the rest of your repositories and let Renovate manage your dependencies' health.
 
 ### Upcoming Tutorials:
 
-We have more advanced Renovate tutorials in the pipeline and will post updates when they are published.
+We're working on more advanced Renovate tutorials and will post updates when we publish new tutorials.
 
 What’s coming next:
 
@@ -312,9 +310,6 @@ What’s coming next:
 - Grouping
 - Schedule
 - Package Rules
-- GitHub actions
+- GitHub Actions
 - PR Assignees and PR reviewers
 - Regex Managers
-
-
-


### PR DESCRIPTION
## Changes:

- Fix some typos
- Fix capitalization
- Drop some newlines
- Fix list display, sometimes by "hard-coding" the numbering order
- Rewrite final "congratulations" section so it uses one heading and normal text for the rest

## Context:

Fixing up a problem found by @betterPeleg:

> hi @HonkingGoose ,
> the new list syntax doesn't show properly on the actual document.
> any idea why?
> should i revert it?